### PR TITLE
Swapped file locks to use thead locks instead

### DIFF
--- a/GivTCP/GivLUT.py
+++ b/GivTCP/GivLUT.py
@@ -232,29 +232,3 @@ class GivLUT:
     def getTime(timestamp):
         timeslot=timestamp.strftime("%H:%M")
         return (timeslot)
-
-    def consecFails():
-        from os.path import exists
-        import os
-        import pickle
-        logger= GivLUT.logger
-
-        if exists(GivLUT.oldDataCount):
-            with open(GivLUT.oldDataCount, 'rb') as inp:
-                oldDataCount= pickle.load(inp)
-            oldDataCount=oldDataCount+1
-        else:
-            oldDataCount=1
-        logger.critical("Consecutive failure count= "+str(oldDataCount))
-        if oldDataCount>10:
-            #10 error in a row so delete regCache data
-            logger.critical("10 failed invertor reads in a row so removing regCache to force update...")
-            if exists(GivLUT.regcache):
-                os.remove(GivLUT.regcache)
-            if exists(GivLUT.batterypkl):
-                os.remove(GivLUT.batterypkl)
-            if exists(GivLUT.oldDataCount):
-                os.remove(GivLUT.oldDataCount)
-        else:
-            with open(GivLUT.oldDataCount, 'wb') as outp:
-                pickle.dump(oldDataCount, outp, pickle.HIGHEST_PROTOCOL)

--- a/GivTCP/settings_template.py
+++ b/GivTCP/settings_template.py
@@ -11,7 +11,7 @@ class GiV_Settings:
     Log_Level="Error"               #Optional - Enables logging level. Default is "Error", but can be "Info", "Critical" or "Debug"
     Print_Raw_Registers=True        #Optional - Bool - True publishes all available registers.
     cache_location="/config/GivTCP" #Optional - default is "/config/GivTCP"
-    data_smoother="High"            #Required - sets the level of data smoothing applied to certain data. High, Medium or low
+    data_smoother="High"            #Required - sets the level of data smoothing applied to certain data. High, Medium, Low, or None to disable
 
 # MQTT Output Settings
     MQTT_Output= True               #Optional - Bool - True or False

--- a/config.yaml
+++ b/config.yaml
@@ -1,6 +1,6 @@
 name:  "GivTCP"
 description:  "TCP Modbus connection to MQTT/JSON for Givenergy Battery/PV Invertors"
-version:  "2.0.6"
+version:  "2.0.7"
 image: britkat/giv_tcp-ma
 slug:  "givtcp"
 init:  true

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -46,7 +46,7 @@ services:
       - GEAPI=                        # API Key for the GivEnergy Cloud
       - SOLCASTAPI=                   # API key for Solcast
       - SOLCASTSITEID=                # SiteID for Solcast site (single array)
-      - DATASMOOTHER=High             # Set the data smoothing to most agressive setting (High, medium, low)
+      - DATASMOOTHER=High             # Set the data smoothing to most agressive setting (High, medium, low, none)
 
     restart: always
     privileged: true


### PR DESCRIPTION
* Put critical sections around:
  - Getting inverter data
  - Read/write the local cache file
 
* Moved some code from `GivLUT` into `read`, because it was only used in one place and belongs to the orchestration logic rather than the Inverter abstraction.
* Changed some `info` sections to `debug` to reduce log noise, because they're only really relevant when debugging.
* Prevented the `pubFromPickle` from running the Inverter fetch, to make a clearer semantic description from `runAll` and to avoid possible race conditions or deadlocks.
* Removed the use of a queue in the `runAll` command because the critical section locks should prevent issued with overlapped calls now.